### PR TITLE
fix: fixed translation on inter sales and purchase buttons

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.js
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.js
@@ -464,8 +464,8 @@ erpnext.buying.PurchaseOrderController = class PurchaseOrderController extends (
 						if (internal) {
 							let button_label =
 								me.frm.doc.company === me.frm.doc.represents_company
-									? "Internal Sales Order"
-									: "Inter Company Sales Order";
+										? __("Internal Sales Order")
+										: __("Inter Company Sales Order");
 
 							me.frm.add_custom_button(
 								button_label,

--- a/erpnext/buying/doctype/purchase_order/purchase_order.js
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.js
@@ -464,8 +464,8 @@ erpnext.buying.PurchaseOrderController = class PurchaseOrderController extends (
 						if (internal) {
 							let button_label =
 								me.frm.doc.company === me.frm.doc.represents_company
-										? __("Internal Sales Order")
-										: __("Inter Company Sales Order");
+									? __("Internal Sales Order")
+									: __("Inter Company Sales Order");
 
 							me.frm.add_custom_button(
 								button_label,

--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -732,8 +732,8 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 						if (internal) {
 							let button_label =
 								me.frm.doc.company === me.frm.doc.represents_company
-									? "Internal Purchase Order"
-									: "Inter Company Purchase Order";
+									? __("Internal Purchase Order")
+									: __("Inter Company Purchase Order");
 
 							me.frm.add_custom_button(
 								button_label,


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

Buttons for Internal Sales Orders/Internal Purchase Orders and Inter Company Sales Order/Inter Company Purchase Order were missing translations because strings were missing function: __()

> Explain the **details** for making this change. What existing problem does the pull request solve?

Added __() to relevant strings

> Screenshots/GIFs

![aftertranslation](https://github.com/user-attachments/assets/f15ab32d-ee50-47be-9e29-5465b6b9fb8b)
![aftertranslation(fix)](https://github.com/user-attachments/assets/0944a9f8-8e44-4925-bccd-90ac9bdd1f2c)



Fixes issue https://github.com/frappe/erpnext/issues/47519
